### PR TITLE
Adding `x-icon` to Spec file samples

### DIFF
--- a/api/product-api/src/main/resources/product-integration-api-v1.yaml
+++ b/api/product-api/src/main/resources/product-integration-api-v1.yaml
@@ -6,6 +6,7 @@ info:
   license:
     name: Copyright Backbase
     url: https://www.backbase.com/legal
+  x-icon: credit_card
 servers:
   - description: Prism mock server
     url: http://localhost:4010

--- a/api/product-api/src/main/resources/product-service-api-v1.yaml
+++ b/api/product-api/src/main/resources/product-service-api-v1.yaml
@@ -6,6 +6,7 @@ info:
   license:
     name: Copyright Backbase
     url: https://www.backbase.com/legal
+  x-icon: credit_card
 servers:
   - description: Prism mock server
     url: http://localhost:4010

--- a/api/review-service-api/src/main/resources/openapi-v1.yaml
+++ b/api/review-service-api/src/main/resources/openapi-v1.yaml
@@ -6,6 +6,7 @@ info:
   license:
     name: Copyright Backbase
     url: https://www.backbase.com/legal
+  x-icon: credit_card
 servers:
   - description: Prism mock server
     url: http://localhost:4010

--- a/api/store-client-api/src/main/resources/openapi-v1.yaml
+++ b/api/store-client-api/src/main/resources/openapi-v1.yaml
@@ -6,6 +6,7 @@ info:
   license:
     name: License
     url: http://atorres.es
+  x-icon: credit_card
 servers:
   - description: Prism mock server
     url: http://localhost:4010


### PR DESCRIPTION
Adding the `x-icon` property would allow teams to add an icon to display in the API Dashboard.