### PR TITLE
Put dependencies with annotation processors to correct order (first lombok, then mapstruct)

### DIFF
--- a/services/product/pom.xml
+++ b/services/product/pom.xml
@@ -63,6 +63,11 @@
             <groupId>com.backbase.buildingblocks</groupId>
             <artifactId>persistence</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- POJO <-> Entity conversion made easy
             https://community.backbase.com/documentation/ServiceSDK/latest/service_sdk_ref_service_sdk_starter_mapping -->
         <dependency>
@@ -80,11 +85,6 @@
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-annotations</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <optional>true</optional>
         </dependency>
 
         <dependency>

--- a/services/product/pom.xml
+++ b/services/product/pom.xml
@@ -63,6 +63,7 @@
             <groupId>com.backbase.buildingblocks</groupId>
             <artifactId>persistence</artifactId>
         </dependency>
+        <!-- lombok has to appear before mapstruct, otherwise mapstruct fails to generate the mappers -->
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>

--- a/services/review/pom.xml
+++ b/services/review/pom.xml
@@ -47,6 +47,7 @@
             <groupId>com.backbase.buildingblocks</groupId>
             <artifactId>persistence</artifactId>
         </dependency>
+        <!-- lombok has to appear before mapstruct, otherwise mapstruct fails to generate the mappers -->
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>

--- a/services/review/pom.xml
+++ b/services/review/pom.xml
@@ -47,6 +47,11 @@
             <groupId>com.backbase.buildingblocks</groupId>
             <artifactId>persistence</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- POJO <-> Entity conversion made easy
             https://community.backbase.com/documentation/ServiceSDK/latest/service_sdk_ref_service_sdk_starter_mapping -->
         <dependency>
@@ -64,11 +69,6 @@
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-annotations</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <optional>true</optional>
         </dependency>
 
         <dependency>

--- a/services/store/pom.xml
+++ b/services/store/pom.xml
@@ -32,6 +32,11 @@
             <groupId>com.backbase.buildingblocks</groupId>
             <artifactId>multi-tenancy</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Start - POJO <-> Entity conversion made easy
              https://community.backbase.com/documentation/ServiceSDK/latest/service_sdk_ref_service_sdk_starter_mapping -->
         <dependency>
@@ -59,11 +64,6 @@
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-annotations</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <optional>true</optional>
         </dependency>
 
         <dependency>

--- a/services/store/pom.xml
+++ b/services/store/pom.xml
@@ -32,6 +32,7 @@
             <groupId>com.backbase.buildingblocks</groupId>
             <artifactId>multi-tenancy</artifactId>
         </dependency>
+        <!-- lombok has to appear before mapstruct, otherwise mapstruct fails to generate the mappers -->
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>


### PR DESCRIPTION
Latest version of lombok (1.18.22) and mapstruct (1.4.2.Final) the golden-sample-services compilation fails.
After the change in order of the above mentioned dependencies the problem is resolved.
I assume it is connected with the order annotation processors start working.