### PR TITLE
Correct extension for mysql_entities_identity_strategy_override.properties file

### DIFF
--- a/database/DATABASE_IDENTIFIER_STRATEGIES.md
+++ b/database/DATABASE_IDENTIFIER_STRATEGIES.md
@@ -88,7 +88,7 @@ We will just use SEQUENCE by default, and override this with the IDENTITY strate
 Check how we achieve that:
 
 - [Config Class](https://github.com/Backbase/golden-sample-services/tree/main/services/review/src/main/java/com/backbase/goldensample/review/config/IdentityStrategyOverrideConfiguration.java)
-- [Config YML File](https://github.com/Backbase/golden-sample-services/tree/main/services/review/src/main/resources/db/mapping/mysql_entities_identity_strategy_override.yml)
+- [Config .properties File](https://github.com/Backbase/golden-sample-services/tree/main/services/review/src/main/resources/db/mapping/mysql_entities_identity_strategy_override.properties)
 - [MySQL ORM File](https://github.com/Backbase/golden-sample-services/tree/main/services/review/src/main/resources/db/mapping/mysql-orm.xml)
 - [Liquibase changelog](https://github.com/Backbase/golden-sample-services/tree/main/database/review-db/src/main/resources/db/changelog/db.changelog-1.0.0.xml)
                                                                                                      

--- a/services/product/src/main/java/com/backbase/goldensample/product/config/IdentityStrategyOverrideConfiguration.java
+++ b/services/product/src/main/java/com/backbase/goldensample/product/config/IdentityStrategyOverrideConfiguration.java
@@ -20,7 +20,7 @@ import org.springframework.validation.annotation.Validated;
  */
 @Validated
 @Configuration
-@PropertySource("classpath:db/mapping/mysql_entities_identity_strategy_override.yml")
+@PropertySource("classpath:db/mapping/mysql_entities_identity_strategy_override.properties")
 @ConditionalOnExpression("'${backbase.entities-identity-strategy-override}' eq 'true' "
     + "|| ("
     + "'${backbase.entities-identity-strategy-override}' ne 'false' "

--- a/services/product/src/main/resources/db/mapping/mysql_entities_identity_strategy_override.properties
+++ b/services/product/src/main/resources/db/mapping/mysql_entities_identity_strategy_override.properties
@@ -1,0 +1,1 @@
+spring.jpa.mapping-resources=db/mapping/mysql-orm.xml

--- a/services/product/src/main/resources/db/mapping/mysql_entities_identity_strategy_override.yml
+++ b/services/product/src/main/resources/db/mapping/mysql_entities_identity_strategy_override.yml
@@ -1,1 +1,0 @@
-spring.jpa.mapping-resources: db/mapping/mysql-orm.xml

--- a/services/review/src/main/java/com/backbase/goldensample/review/config/IdentityStrategyOverrideConfiguration.java
+++ b/services/review/src/main/java/com/backbase/goldensample/review/config/IdentityStrategyOverrideConfiguration.java
@@ -20,7 +20,7 @@ import org.springframework.validation.annotation.Validated;
  */
 @Validated
 @Configuration
-@PropertySource("classpath:db/mapping/mysql_entities_identity_strategy_override.yml")
+@PropertySource("classpath:db/mapping/mysql_entities_identity_strategy_override.properties")
 @ConditionalOnExpression("'${backbase.entities-identity-strategy-override}' eq 'true' "
     + "|| ("
     + "'${backbase.entities-identity-strategy-override}' ne 'false' "

--- a/services/review/src/main/resources/db/mapping/mysql_entities_identity_strategy_override.properties
+++ b/services/review/src/main/resources/db/mapping/mysql_entities_identity_strategy_override.properties
@@ -1,0 +1,1 @@
+spring.jpa.mapping-resources=db/mapping/mysql-orm.xml

--- a/services/review/src/main/resources/db/mapping/mysql_entities_identity_strategy_override.yml
+++ b/services/review/src/main/resources/db/mapping/mysql_entities_identity_strategy_override.yml
@@ -1,1 +1,0 @@
-spring.jpa.mapping-resources: db/mapping/mysql-orm.xml


### PR DESCRIPTION
`@PropertySource` can load only `.properties` files. Luckily we have only one line in the `mysql_entities_identity_strategy_override.yml` file `spring.jpa.mapping-resources: db/mapping/mysql-orm.xml` which can be successfully read by `@PropertySource`.

See [2.5.1. Mapping YAML to Properties](https://docs.spring.io/spring-boot/docs/current/reference/html/features.html#features.external-config.yaml.mapping-to-properties)

> YAML files cannot be loaded by using the `@PropertySource` or `@TestPropertySource` annotations. So, in the case that you need to load values that way, you need to use a properties file.

In this PR we change the override config file extension from `.yml` to `.properties` to comply with `@PropertySource` annotation requirements.