### PR TITLE
Testcontainers MySql configuration override.

### DIFF
--- a/TESTCONTAINERS.md
+++ b/TESTCONTAINERS.md
@@ -197,6 +197,13 @@ For more information about tmpfs mount, see the [official Docker documentation](
 
 More info: https://www.testcontainers.org/modules/databases/jdbc/
 
+##### Running MySql container overriding my.cnf settings
+
+For MySQL databases, it is possible to override configuration settings using resources on the classpath. 
+Assuming `db/mysql_conf_override` is a directory on the classpath containing `.cnf` files, the following URL can be used:
+
+`jdbc:tc:mysql:5.7:///databasename?TC_MY_CNF=db/mysql_conf_override`
+
 ##### Database container objects
 In case you can't use the URL support, or need to fine-tune the container, you can instantiate it yourself.
 Add a `@Rule` or `@ClassRule` to your test class, e.g.:

--- a/services/product/src/test/resources/application-m10y.yaml
+++ b/services/product/src/test/resources/application-m10y.yaml
@@ -4,12 +4,12 @@ backbase:
     tenants:
       - id: org_shop
         datasource:
-          url: jdbc:tc:mysql:5.7:///testdb1
+          url: jdbc:tc:mysql:5.7:///testdb1?TC_MY_CNF=db/mysql_conf_override
           username: test
           password: test
       - id: rebrand_shop
         datasource:
-          url: jdbc:tc:mysql:5.7:///testdb2
+          url: jdbc:tc:mysql:5.7:///testdb2?TC_MY_CNF=db/mysql_conf_override
           username: test
           password: test
     datasource:

--- a/services/product/src/test/resources/application.yaml
+++ b/services/product/src/test/resources/application.yaml
@@ -14,7 +14,7 @@ spring:
     driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
 #   Useful if we want to load the Database with a lot of data before the test kick in (disable liquibase first)
 #    url: jdbc:tc:mysql:5.7:///test?TC_INITSCRIPT=file:src/test/resources/product-10k-rows.sql
-    url: jdbc:tc:mysql:5.7:///test
+    url: jdbc:tc:mysql:5.7:///test?TC_MY_CNF=db/mysql_conf_override
     username: test
     password: test
 

--- a/services/product/src/test/resources/db/mysql_conf_override/my.cnf
+++ b/services/product/src/test/resources/db/mysql_conf_override/my.cnf
@@ -1,0 +1,13 @@
+[mysqld]
+skip-name-resolve
+explicit_defaults_for_timestamp
+max_connections=2000
+max_allowed_packet=512M
+
+sort_buffer_size=2M
+
+character-set-server=utf8mb4
+collation-server=utf8mb4_unicode_ci
+
+[mysql]
+default-character-set=utf8mb4

--- a/services/review/src/test/resources/application-m10y.yaml
+++ b/services/review/src/test/resources/application-m10y.yaml
@@ -4,12 +4,12 @@ backbase:
     tenants:
       - id: org_shop
         datasource:
-          url: jdbc:tc:mysql:5.7:///testdb1
+          url: jdbc:tc:mysql:5.7:///testdb1?TC_MY_CNF=db/mysql_conf_override
           username: test
           password: test
       - id: rebrand_shop
         datasource:
-          url: jdbc:tc:mysql:5.7:///testdb2
+          url: jdbc:tc:mysql:5.7:///testdb2?TC_MY_CNF=db/mysql_conf_override
           username: test
           password: test
     datasource:

--- a/services/review/src/test/resources/application.yaml
+++ b/services/review/src/test/resources/application.yaml
@@ -11,7 +11,7 @@ spring:
   datasource:
     ## You often do not need to specify the driver-class-name,
     ## since Spring Boot can deduce it for most databases from the url.
-    url: jdbc:tc:mysql:5.7:///databasename
+    url: jdbc:tc:mysql:5.7:///databasename?TC_MY_CNF=db/mysql_conf_override
     username: test
     password: test
 

--- a/services/review/src/test/resources/db/mysql_conf_override/my.cnf
+++ b/services/review/src/test/resources/db/mysql_conf_override/my.cnf
@@ -1,0 +1,13 @@
+[mysqld]
+skip-name-resolve
+explicit_defaults_for_timestamp
+max_connections=2000
+max_allowed_packet=512M
+
+sort_buffer_size=2M
+
+character-set-server=utf8mb4
+collation-server=utf8mb4_unicode_ci
+
+[mysql]
+default-character-set=utf8mb4


### PR DESCRIPTION
Adding my.cnf configuration override to run integration tests on pre-configured MySql.