### PR TITLE
chore: Remove not used persistence layer arch unit tests in store service

### DIFF
--- a/services/store/src/test/java/com/backbase/goldensample/store/archunit/ArchUnitRulesTest.java
+++ b/services/store/src/test/java/com/backbase/goldensample/store/archunit/ArchUnitRulesTest.java
@@ -1,19 +1,16 @@
 package com.backbase.goldensample.store.archunit;
 
-import com.backbase.buildingblocks.archunit.ArchitectureRules;
 import com.backbase.buildingblocks.archunit.test.AllArchitectureRules;
 import com.backbase.buildingblocks.archunit.test.AllConfigurationRules;
 import com.backbase.buildingblocks.archunit.test.AllControllerRules;
 import com.backbase.buildingblocks.archunit.test.AllGeneralCodingRules;
 import com.backbase.buildingblocks.archunit.test.AllLoggingRules;
 import com.backbase.buildingblocks.archunit.test.AllNamingConventionRules;
-import com.backbase.buildingblocks.archunit.test.AllRelationalPersistenceRules;
 import com.backbase.goldensample.store.Application;
 import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.junit.ArchTests;
-import com.tngtech.archunit.lang.syntax.elements.GivenClassesConjunction;
 
 @AnalyzeClasses(packagesOf = Application.class, importOptions = ImportOption.DoNotIncludeTests.class)
 public class ArchUnitRulesTest {
@@ -35,8 +32,4 @@ public class ArchUnitRulesTest {
 
     @ArchTest
     ArchTests namingConventionRules = ArchTests.in(AllNamingConventionRules.class);
-
-    // No Persistence in this module.
-    // @ArchTest
-    // ArchTests relationalPersistenceRules = ArchTests.in(AllRelationalPersistenceRules.class);
 }


### PR DESCRIPTION
Service does not have persistence layer, so no arch unit needed, cleaning up commented out code.
Closes #147 